### PR TITLE
Error with NSOpenPanel

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4825,7 +4825,7 @@ namespace MonoMac.AppKit {
 		NSOpenPanel OpenPanel { get; }
 
 		[Export ("URLs")]
-		string [] Urls { get; }
+		NSUrl [] Urls { get; }
 
 		//Detected properties
 		[Export ("resolvesAliases")]


### PR DESCRIPTION
Fixed an error with NSOpenPanel. 

The URL (deprecated property filename) can now be accessed as follows:
NSUrl url = openPanel.Urls[0];
String str = url.AbsoluteString;

Best regards from Switzerland,
Andy
