### PR TITLE
NSArrayController added and NSPasteboard updated

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -6195,7 +6195,7 @@ namespace MonoMac.AppKit {
 		bool CanReadItemWithDataConformingToTypes (string [] utiTypes);
 
 		[Export ("canReadObjectForClasses:options:")]
-		bool CanReadObjectForClassesoptions (NSPasteboardReading [] classArray, NSDictionary options);
+		bool CanReadObjectForClassesoptions (NSArray classArray, NSDictionary options);
 
 		[Export ("declareTypes:owner:")]
 		int DeclareTypesowner (string [] newTypes, NSObject newOwner);
@@ -6289,15 +6289,6 @@ namespace MonoMac.AppKit {
 		
 		[Field ("NSPasteboardURLReadingFileURLsOnlyKey")]
 		NSString NSPasteboardURLReadingFileURLsOnlyKey { get; }
-		
-		/*
-		[Static]
-		[Export ("URLFromPasteboard:")]
-		NSUrl URLFromPasteboard ([Target] NSUrl url, NSPasteboard pasteBoard);
-				
-		[Export ("writeToPasteboard:")]
-		void WriteToPasteboard ([Target] NSUrl url, NSPasteboard pasteBoard);
-		*/
 	}
 	
 	[BaseType (typeof (NSObject))]


### PR DESCRIPTION
I´ve added the NSArrayController class and added some fields to NSPasteboard and changed the signature of ReadObjectsForClassesoptions and CanReadObjectForClassesoptions in order to make possible to send types that we know they implement NSPasteboardReading in Cocoa side but in monomac side they don´t inherit the subclass generated from the protocol. I´ve tried invoking this method and it worked.
