### PR TITLE
Provide access to NSSearchPathForDirectoriesInDomains for 10.5 support

### DIFF
--- a/src/Foundation/NSSearchPath.cs
+++ b/src/Foundation/NSSearchPath.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.InteropServices;
+
+using MonoMac.ObjCRuntime;
+
+namespace MonoMac.Foundation {
+
+	public static class NSSearchPath {
+	
+		[DllImport (Constants.FoundationLibrary)]
+		extern static IntPtr  NSSearchPathForDirectoriesInDomains (NSSearchPathDirectory directory, NSSearchPathDomain domainMask, bool expandTilde);
+	
+		public static string[] GetDirectories (NSSearchPathDirectory directory, NSSearchPathDomain domainMask, bool expandTilde)
+		{
+			IntPtr values = NSSearchPathForDirectoriesInDomains(directory, domainMask, expandTilde);
+			return NSArray.StringArrayFromHandle (values);
+		}
+	}
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,6 +37,7 @@ CORE_SOURCES =					\
 # Sources that are not part of CORE_SOURCES or the generated templates
 MONOMAC_SOURCES = \
 	./Foundation/NSObjectMac.cs			\
+	./Foundation/NSSearchPath.cs		\
 	./AppKit/ActionDispatcher.cs			\
 	./AppKit/BeginSheet.cs				\
 	./AppKit/DoubleWrapper.cs			\


### PR DESCRIPTION
OSX 10.5 can't access NSFileManager.DefaultManager.GetUrl(), this is the alternative.

Not sure if this is the correct pattern for framework functions that aren't part of an obj-c object.
