### PR TITLE
Fix NSTextFieldDelegate.GetCompletions when not handled explicitly

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -10713,7 +10713,7 @@ namespace MonoMac.AppKit {
 		[Export ("control:textView:doCommandBySelector:"), DelegateName ("NSControlCommand"), DefaultValue (false)]
 		bool DoCommandBySelector (NSControl control, NSTextView textView, Selector commandSelector);
 
-		[Export ("control:textView:completions:forPartialWordRange:indexOfSelectedItem:"), DelegateName ("NSControlTextFilter"), DefaultValue (null)]
+		[Export ("control:textView:completions:forPartialWordRange:indexOfSelectedItem:"), DelegateName ("NSControlTextFilter"), DefaultValue ("new string[0]")]
 		string [] GetCompletions (NSControl control, NSTextView textView, string [] words, NSRange charRange, int index);
 
 		[Export ("controlTextDidEndEditing:"), EventArgs ("NSNotification")]


### PR DESCRIPTION
When handling C# style events, the generated _NSTextFieldDelegate is used, which causes an error when NSTextFieldDelegate.GetCompletions is called (user presses escape and application crashes).  The default value should not be null, but an empty array.
