### PR TITLE
This will fix an error when rendering a scene if the frame value gets out of sync

### DIFF
--- a/src/OpenGL/MonoMacGameView.cs
+++ b/src/OpenGL/MonoMacGameView.cs
@@ -487,6 +487,10 @@ namespace MonoMac.OpenGL
 				prevUpdateTime = curUpdateTime;
 			}
 			var t = (curUpdateTime - prevUpdateTime).TotalSeconds;
+
+			// This fixes a potential error
+			if (t <= 0) t = Double.Epsilon;
+
 			updateEventArgs.Time = t;
 			OnUpdateFrame (updateEventArgs);
 			prevUpdateTime = curUpdateTime;
@@ -496,6 +500,10 @@ namespace MonoMac.OpenGL
 				prevRenderTime = curRenderTime;
 			}
 			t = (curRenderTime - prevRenderTime).TotalSeconds;
+
+			// This fixes a potential error
+			if (t <= 0) t = Double.Epsilon;
+			
 			renderEventArgs.Time = t;
 			OnRenderFrame (renderEventArgs);
 			prevRenderTime = curRenderTime;


### PR DESCRIPTION
Fix a potential rendering error for the time value.  Fix suggested by espies.

This does not happen often but still needs to be there just in case.  If the case happens where time <= 0 then the program will just up in quit which is not good.
