### PR TITLE
Add a default SynchronizationContext for the main UI thread

### DIFF
--- a/src/AppKit/AppKitSynchronizationContext.cs
+++ b/src/AppKit/AppKitSynchronizationContext.cs
@@ -1,0 +1,25 @@
+//
+// AppKitSynchronizationContext.cs: Default SynchronizationContext for the main UI thread
+//
+using System.Threading;
+
+using MonoMac.Foundation;
+
+namespace MonoMac.AppKit {
+	class AppKitSynchronizationContext : SynchronizationContext {
+		public override SynchronizationContext CreateCopy ()
+		{
+			return new AppKitSynchronizationContext ();
+		}
+
+		public override void Post (SendOrPostCallback d, object state)
+		{
+			NSRunLoop.Main.BeginInvokeOnMainThread (() => d (state));
+		}
+
+		public override void Send (SendOrPostCallback d, object state)
+		{
+			NSRunLoop.Main.InvokeOnMainThread (() => d (state));
+		}
+	}
+}

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using MonoMac;
 using MonoMac.Foundation;
@@ -71,6 +72,8 @@ namespace MonoMac.AppKit {
 
 		public static void Main (string [] args)
 		{
+			SynchronizationContext.SetSynchronizationContext (new AppKitSynchronizationContext ());
+			
 			NSApplicationMain (args.Length, args);
 		}
 	}

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,7 @@ CORE_SOURCES =					\
 MONOMAC_SOURCES = \
 	./Foundation/NSObjectMac.cs			\
 	./Foundation/NSSearchPath.cs		\
+	./AppKit/AppKitSynchronizationContext.cs	\
 	./AppKit/ActionDispatcher.cs			\
 	./AppKit/BeginSheet.cs				\
 	./AppKit/DoubleWrapper.cs			\


### PR DESCRIPTION
This change adds a default `SynchronizationContext` for the main UI thread so TPL's `TaskScheduler.FromCurrentSynchronizationContext()` can be used with `ContinueWith` to get back on the UI thread.

This is similar to a change that was made to MonoTouch (#[690944](https://bugzilla.novell.com/show_bug.cgi?id=690944)).
