### PR TITLE
Make NSTextViewDelegate inherit from NSTextDelegate

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -12669,7 +12669,7 @@ namespace MonoMac.AppKit {
 		NSTextCheckingTypes EnabledTextCheckingTypes { get; set; }
 	}
 
-	[BaseType (typeof (NSObject))]
+	[BaseType (typeof (NSTextDelegate))]
 	[Model]
 	public interface NSTextViewDelegate {
 		[Export ("textView:clickedOnLink:atIndex:"), DelegateName ("NSTextViewLink"), DefaultValue (false)]


### PR DESCRIPTION
According to [Apple's reference documentation](http://developer.apple.com/library/mac/#documentation/cocoa/Reference/NSTextViewDelegate_Protocol/Reference/Reference.html) the _NSTextViewDelegate_ protocol “conforms to” the _NSTextDelegate_ protocol.

By merging this pull request our _NSTextViewDelegate_ implementations get fun stuff like this:

``` c#
public override void TextDidChange (NSNotification notification)
{
    // call the police.
}
```
