### PR TITLE
Remove model attribute from WebOpenPanelResultListener

### DIFF
--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -1452,7 +1452,6 @@ namespace MonoMac.WebKit {
 	}
 
 	[BaseType (typeof (NSObject))]
-	[Model]
 	interface WebOpenPanelResultListener {
 		[Export ("chooseFilename:")]
 		void ChooseFilename (string filename);


### PR DESCRIPTION
Remove model attribute from WebOpenPanelResultListener so overriding WebUIDelegate.UIRunOpenPanelForFileButton doesn't crash
