### PR TITLE
Added Support for OS X 1.8 User Notification Center 

### DIFF
--- a/src/Foundation/EnumDesktop.cs
+++ b/src/Foundation/EnumDesktop.cs
@@ -79,4 +79,11 @@ namespace MonoMac.Foundation {
 		AppleEvent = 1634039412, // 'aevt'
 		Internet = 1196773964, // 'GURL'
 	}
+
+	// Added from NSUserNotification.h
+	public enum NSUserNotificationActivationType {
+		None = 0,
+		ContentsClicked = 1,
+		ActionButtonClicked = 2
+	}
 }

--- a/src/foundation-desktop.cs
+++ b/src/foundation-desktop.cs
@@ -526,4 +526,107 @@ namespace MonoMac.Foundation {
 		[Export ("transformedValue:")]
 		NSObject TransformedValue (NSObject value);
 	}
+
+	[BaseType (typeof (NSObject))]
+	public interface NSUserNotification 
+	{
+		[Export ("title")]
+		string Title { get; set; }
+		
+		[Export ("subtitle")]
+		string Subtitle { get; set; }
+		
+		[Export ("informativeText")]
+		string InformativeText { get; set; }
+		
+		[Export ("actionButtonTitle")]
+		string ActionButtonTitle { get; set; }
+		
+		[Export ("userInfo")]
+		NSDictionary UserInfo { get; set; }
+		
+		[Export ("deliveryDate")]
+		NSDate DeliveryDate { get; set; }
+		
+		[Export ("deliveryTimeZone")]
+		NSTimeZone DeliveryTimeZone { get; set; }
+		
+		[Export ("deliveryRepeatInterval")]
+		NSDateComponents DeliveryRepeatInterval { get; set; }
+		
+		[Export ("actualDeliveryDate")]
+		NSDate ActualDeliveryDate { get; }
+		
+		[Export ("presented")]
+		bool Presented { [Bind("isPresented")] get; }
+		
+		[Export ("remote")]
+		bool Remote { [Bind("isRemote")] get; }
+		
+		[Export ("soundName")]
+		string SoundName { get; set; }
+		
+		[Export ("hasActionButton")]
+		bool HasActionButton { get; set; }
+		
+		[Export ("activationType")]
+		NSUserNotificationActivationType ActivationType { get; }
+		
+		[Export ("otherButtonTitle")]
+		string OtherButtonTitle { get; set; }
+		
+		[Field ("NSUserNotificationDefaultSoundName")]
+		NSString NSUserNotificationDefaultSoundName { get; }
+	}
+	
+	[BaseType (typeof (NSObject),
+	           Delegates=new string [] {"WeakDelegate"},
+	Events=new Type [] { typeof (NSUserNotificationCenterDelegate) })]
+	public interface NSUserNotificationCenter 
+	{
+		[Export ("defaultUserNotificationCenter")][Static]
+		NSUserNotificationCenter DefaultUserNotificationCenter { get; }
+		
+		[Export ("delegate")][NullAllowed]
+		NSObject WeakDelegate { get; set; }
+		
+		[Wrap ("WeakDelegate")][NullAllowed]
+		NSUserNotificationCenterDelegate Delegate { get; set; }
+		
+		[Export ("scheduledNotifications")]
+		NSUserNotification [] ScheduledNotifications { get; set; }
+		
+		[Export ("scheduleNotification:")]
+		void ScheduleNotification (NSUserNotification notification);
+		
+		[Export ("removeScheduledNotification:")]
+		void RemoveScheduledNotification (NSUserNotification notification);
+		
+		[Export ("deliveredNotifications")]
+		NSUserNotification [] DeliveredNotifications { get; }
+		
+		[Export ("deliverNotification:")]
+		void DeliverNotification (NSUserNotification notification);
+		
+		[Export ("removeDeliveredNotification:")]
+		void RemoveDeliveredNotification (NSUserNotification notification);
+		
+		[Export ("removeAllDeliveredNotifications")]
+		void RemoveAllDeliveredNotifications ();
+	}
+	
+	[BaseType (typeof (NSObject))]
+	[Model]
+	public interface NSUserNotificationCenterDelegate 
+	{
+		[Export ("userNotificationCenter:didDeliverNotification:"), EventArgs ("UNCDidDeliverNotification")]
+		void DidDeliverNotification (NSUserNotificationCenter center, NSUserNotification notification);
+		
+		[Export ("userNotificationCenter:didActivateNotification:"), EventArgs ("UNCDidActivateNotification")]
+		void DidActivateNotification (NSUserNotificationCenter center, NSUserNotification notification);
+		
+		[Export ("userNotificationCenter:shouldPresentNotification:"), DelegateName ("UNCShouldPresentNotification"), DefaultValue (false)]
+		bool ShouldPresentNotification (NSUserNotificationCenter center, NSUserNotification notification);
+	}
+
 }


### PR DESCRIPTION
Added NSUserNotification, NSUserNotificationCenter and NSUserNotificationCenterDelegate Classes

So now we are able to use notifications in MonoMac Projects

Simple Example

```
            NSUserNotification not = new NSUserNotification();
            not.Title = "Hello World";
            not.InformativeText = "This is an informative text";
            not.DeliveryDate = DateTime.Now;
            not.SoundName = NSUserNotification.NSUserNotificationDefaultSoundName;

            NSUserNotificationCenter center = NSUserNotificationCenter.DefaultUserNotificationCenter;

            center.DidDeliverNotification += (sender, e) => 
            {
                Console.WriteLine("Notification Delivered");
            };

            center.DidActivateNotification += (sender, e) => 
            {
                Console.WriteLine("Notification Touched");
            };

            center.ShouldPresentNotification = (c, n) => { return true; };

            center.ScheduleNotification(not);
```
