### PR TITLE
Raise an exception if the superclass you're trying to find is not registered yet

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -107,6 +107,13 @@ namespace MonoMac.ObjCRuntime {
 					return type;
 				}
 
+				if ( kls == IntPtr.Zero ) {
+					var message = "Could not find a valid superclass for type " + new Class(orig_klass).Name 
+					+  ". Did you forget to register the bindings at " + typeof(Class).FullName
+					+  ".Register() or call NSApplication.Init()?";
+					throw new ArgumentException(message);
+				}
+
 				klass = kls;
 			} while (true);
 		}


### PR DESCRIPTION
Found this issue while running some specific tests of our test suite. In the case you didn't call `NSApplication.Init()` or didn't register the types yourself at `MonoMac.ObjCRuntime` the `Lookup` method enters an eternal loop because `kls` is always `IntPtr.Zero` and calling `class_getSuperclass` with `IntPtr.Zero` also returns zero.

Since the code is a `while(true)` it never goes out of the loop and the thread is stuck forever. This PR makes it raise an exception if it reaches this case instead of being locked forever.
