### PR TITLE
NSObject.PerformSelector should allow null for object

### DIFF
--- a/src/Foundation/NSObject.cs
+++ b/src/Foundation/NSObject.cs
@@ -260,8 +260,6 @@ namespace MonoMac.Foundation {
 		public virtual void PerformSelector (Selector sel, NSObject obj, double delay) {
 			if (sel == null)
 				throw new ArgumentNullException ("sel");
-			if (obj == null)
-				throw new ArgumentNullException ("obj");
 			if (IsDirectBinding) {
 				Messaging.void_objc_msgSend_intptr_intptr_double (this.Handle, selPerformSelectorWithObjectAfterDelay, sel.Handle, obj == null ? IntPtr.Zero : obj.Handle, delay);
 			} else {


### PR DESCRIPTION
See docs: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/Reference/Reference.html#//apple_ref/occ/instm/NSObject/performSelector:withObject:afterDelay:
