### PR TITLE
Update Make.shared with missing files

### DIFF
--- a/src/Make.shared
+++ b/src/Make.shared
@@ -92,6 +92,7 @@ SHARED_SOURCE = \
 	./Foundation/NSAutoreleasePool.cs		\
 	./Foundation/NSArray.cs				\
 	./Foundation/NSBundle.cs			\
+	./Foundation/NSCalendar.cs			\	
 	./Foundation/NSCoder.cs				\
 	./Foundation/NSData.cs				\
 	./Foundation/NSDate.cs				\


### PR DESCRIPTION
A few useful files appear to have been missed from the MonoTouch conversion. This adds them to the project but requires that the updated .cs files be added to maccore first. See the related pull request: https://github.com/mono/maccore/pull/35
