### PR TITLE
Add AOT callback attributes to ObjCRuntime

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -303,7 +303,8 @@ namespace MonoMac.ObjCRuntime {
 
 			return false;
 		}
-		
+
+		[MonoNativeFunctionWrapper]
 		delegate int getFrameLengthDelegate (IntPtr @this, IntPtr sel);
 		static getFrameLengthDelegate getFrameLength = Selector.GetFrameLength;
 		static IntPtr getFrameLengthPtr = Marshal.GetFunctionPointerForDelegate (getFrameLength);

--- a/src/ObjCRuntime/Selector.cs
+++ b/src/ObjCRuntime/Selector.cs
@@ -56,6 +56,10 @@ namespace MonoMac.ObjCRuntime {
 
 		public Selector (string name) : this (name, false) {}
 
+		[MonoNativeFunctionWrapper]
+		delegate int getFrameLengthDelegate (IntPtr @this, IntPtr sel);
+
+		[MonoPInvokeCallbackAttribute(typeof(getFrameLengthDelegate))]
 		public static int GetFrameLength (IntPtr @this, IntPtr sel)
 		{
 			IntPtr sig = Messaging.IntPtr_objc_msgSend_IntPtr (@this, MethodSignatureForSelector, sel);


### PR DESCRIPTION
Delegates that are the target of Marshal.GetFunctionPointerForDelegate and passed to native must have a MonoNativeFunctionWrapper attribute. Managed methods that are the target of a native callback invocation must have a MonoPInvokeCallback attribute. These are required to support execution under AOT builds.
