### PR TITLE
[Fix] NSWindow and NSBitmapImageRep must not export NSObjectFlag

### DIFF
--- a/src/AppKit/NSBitmapImageRep.cs
+++ b/src/AppKit/NSBitmapImageRep.cs
@@ -29,8 +29,11 @@ namespace MonoMac.AppKit {
 	public partial class NSBitmapImageRep {
 		static IntPtr selInitForIncrementalLoad = Selector.GetHandle ("initForIncrementalLoad");
 
-		[Export ("initForIncrementalLoad")]
-		public NSBitmapImageRep (NSObjectFlag a, NSObjectFlag b) : base (a)
+		// Do not actually export because NSObjectFlag is not exportable.
+		// The Objective C method already exists. This is just to allow
+		// access on the managed side via the static method.
+		//[Export ("initForIncrementalLoad")]
+		private NSBitmapImageRep (NSObjectFlag a, NSObjectFlag b) : base (a)
 		{
 			if (IsDirectBinding) {
 				Handle = MonoMac.ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, selInitForIncrementalLoad);

--- a/src/AppKit/NSWindow.cs
+++ b/src/AppKit/NSWindow.cs
@@ -30,8 +30,11 @@ namespace MonoMac.AppKit {
 	public partial class NSWindow {
 		static IntPtr selInitWithWindowRef = Selector.GetHandle ("initWithWindowRef:");
 
-		[Export ("initWithWindowRef:")]
-		public NSWindow (IntPtr windowRef, NSObjectFlag x) : base (NSObjectFlag.Empty)
+		// Do not actually export because NSObjectFlag is not exportable.
+		// The Objective C method already exists. This is just to allow
+		// access on the managed side via the static method.
+		//[Export ("initWithWindowRef:")]
+		private NSWindow (IntPtr windowRef, NSObjectFlag x) : base (NSObjectFlag.Empty)
 		{
 			if (IsDirectBinding) {
 				Handle = MonoMac.ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, selInitWithWindowRef);


### PR DESCRIPTION
NSObjectFlag is an unwrapped class which TypeConverter does not know how to serialize. Therefore, it cannot appear on a method with an Export attribute. This fix removes the Export attributes and makes the constructors private because they only exist to serve the static factory methods in the first place. The commented export is left in place for reference and so it isn't accidentally added back.
