### PR TITLE
Fix DrawerMadness sample to use NSObject instead of NSButtonCell

### DIFF
--- a/samples/DrawerMadness/DrawerMadness/ParentWindow.xib.designer.cs
+++ b/samples/DrawerMadness/DrawerMadness/ParentWindow.xib.designer.cs
@@ -30,40 +30,40 @@ namespace DrawerMadness {
 		
 		#pragma warning disable 0169
 		[MonoMac.Foundation.Export("closeBottomDrawer:")]
-		partial void closeBottomDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void closeBottomDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("closeLeftDrawer:")]
-		partial void closeLeftDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void closeLeftDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("closeLowerRightDrawer:")]
-		partial void closeLowerRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void closeLowerRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("closeUpperRightDrawer:")]
-		partial void closeUpperRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void closeUpperRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("openBottomDrawer:")]
-		partial void openBottomDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void openBottomDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("openLeftDrawer:")]
-		partial void openLeftDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void openLeftDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("openLowerRightDrawer:")]
-		partial void openLowerRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void openLowerRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("openUpperRightDrawer:")]
-		partial void openUpperRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void openUpperRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("toggleBottomDrawer:")]
-		partial void toggleBottomDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void toggleBottomDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("toggleLeftDrawer:")]
-		partial void toggleLeftDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void toggleLeftDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("toggleLowerRightDrawer:")]
-		partial void toggleLowerRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void toggleLowerRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Export("toggleUpperRightDrawer:")]
-		partial void toggleUpperRightDrawer (MonoMac.AppKit.NSButtonCell sender);
+		partial void toggleUpperRightDrawer (MonoMac.Foundation.NSObject sender);
 
 		[MonoMac.Foundation.Connect("leftDrawer")]
 		private global::MonoMac.AppKit.NSDrawer leftDrawer {

--- a/samples/DrawerMadness/DrawerMadness/ParentWindowController.cs
+++ b/samples/DrawerMadness/DrawerMadness/ParentWindowController.cs
@@ -86,17 +86,17 @@ namespace DrawerMadness
 		}
 		
 		
-		partial void openLeftDrawer (NSButtonCell sender)
+		partial void openLeftDrawer (NSObject sender)
 		{
 			leftDrawer.OpenOnEdge(NSRectEdge.MinXEdge);
 		}
 		
-		partial void closeLeftDrawer (NSButtonCell sender)
+		partial void closeLeftDrawer (NSObject sender)
 		{
 			leftDrawer.Close(sender);
 		}
 		
-		partial void toggleLeftDrawer (NSButtonCell sender)
+		partial void toggleLeftDrawer (NSObject sender)
 		{
 			
 			NSDrawerState state = leftDrawer.State;
@@ -125,17 +125,17 @@ namespace DrawerMadness
 			};
 		}
 		
-		partial void openBottomDrawer (NSButtonCell sender)
+		partial void openBottomDrawer (NSObject sender)
 		{
 			bottomDrawer.OpenOnEdge(NSRectEdge.MinYEdge);
 		}
 		
-		partial void closeBottomDrawer (NSButtonCell sender)
+		partial void closeBottomDrawer (NSObject sender)
 		{
 			bottomDrawer.Close(sender);
 		}
 		
-		partial void toggleBottomDrawer (NSButtonCell sender)
+		partial void toggleBottomDrawer (NSObject sender)
 		{
 			var state = bottomDrawer.State;
 			if (state == NSDrawerState.Opening || state == NSDrawerState.Open) 
@@ -177,17 +177,17 @@ namespace DrawerMadness
 		}
 		
 			                                                                
-		partial void openUpperRightDrawer (NSButtonCell sender)
+		partial void openUpperRightDrawer (NSObject sender)
 		{
 			upperRightDrawer.OpenOnEdge(NSRectEdge.MaxXEdge);
 		}
 		
-		partial void closeUpperRightDrawer (NSButtonCell sender)
+		partial void closeUpperRightDrawer (NSObject sender)
 		{
 			upperRightDrawer.Close(sender);
 		}
 		
-		partial void toggleUpperRightDrawer (NSButtonCell sender)
+		partial void toggleUpperRightDrawer (NSObject sender)
 		{
 			var state = upperRightDrawer.State;
 			if (state == NSDrawerState.Opening || state == NSDrawerState.Open) 
@@ -210,17 +210,17 @@ namespace DrawerMadness
 			lowerRightDrawer.DrawerShouldClose = DrawerShouldClose;
 		}
 		
-		partial void openLowerRightDrawer (NSButtonCell sender)
+		partial void openLowerRightDrawer (NSObject sender)
 		{
 			lowerRightDrawer.OpenOnEdge(NSRectEdge.MaxXEdge);
 		}
 		
-		partial void closeLowerRightDrawer (NSButtonCell sender)
+		partial void closeLowerRightDrawer (NSObject sender)
 		{
 			lowerRightDrawer.Close(sender);
 		}
 		
-		partial void toggleLowerRightDrawer (NSButtonCell sender)
+		partial void toggleLowerRightDrawer (NSObject sender)
 		{
 			var state = lowerRightDrawer.State;
 			if (state == NSDrawerState.Opening || state == NSDrawerState.Open) 


### PR DESCRIPTION
See bug #8581. Cocoa passes NSMatrix as the sender but the sample was setup to receive NSButtonCell. This fixes the sample by changing messages to receive NSObject but it looks like the tool that generated the designer file needs to be fixed.
