### PR TITLE
Improve exception message when a type cannot be converted during marshaling

### DIFF
--- a/src/ObjCRuntime/NSObjectMarshaler.cs
+++ b/src/ObjCRuntime/NSObjectMarshaler.cs
@@ -29,8 +29,19 @@ namespace MonoMac.ObjCRuntime {
 	public class NSObjectMarshaler<T> : ICustomMarshaler where T : NSObject {
 		static NSObjectMarshaler<T> marshaler;
 
-		public object MarshalNativeToManaged (IntPtr handle) {
-			return (T) Runtime.GetNSObject (handle);
+		public object MarshalNativeToManaged (IntPtr handle)
+		{
+			if (handle == IntPtr.Zero)
+				return null;
+
+			var obj = Runtime.GetNSObject (handle);
+			if (!(obj is T)) {
+				throw new MarshalDirectiveException (
+					string.Format ("NSObjectMarshaler<{0}>: Could not cast from type {1}", typeof(T), obj.GetType ()));
+			}
+			else {
+				return (T) obj;
+			}
 		}
 
 		public IntPtr MarshalManagedToNative (object obj) {


### PR DESCRIPTION
Now when a type cannot be converted a more detailed exception message is generated stating the types converted from and to. This makes it easier to debug applications.
