### PR TITLE
Fix StillMotion sample to keep a reference to the window controller

### DIFF
--- a/samples/StillMotion/StillMotion.cs
+++ b/samples/StillMotion/StillMotion.cs
@@ -12,6 +12,7 @@ namespace StillMotion
 {
 	public partial class StillMotionDocument : NSDocument
 	{
+		NSWindowController windowController;
 		QTMovie movie;
 		QTCaptureSession captureSession;
 		QTCaptureDeviceInput captureInput;
@@ -33,6 +34,11 @@ namespace StillMotion
 		public override void WindowControllerDidLoadNib (NSWindowController windowController)
 		{
 			base.WindowControllerDidLoadNib (windowController);
+
+			// A reference to the window controller must be kept on the managed side
+			// to keep the object from being GC'd so that the delegates below resolve.
+			// Don't remove unless the framework is updated to track the reference.
+			this.windowController = windowController;
 
 			NSError err;
 			


### PR DESCRIPTION
See bug #8585. If the NSWindowController is not cached on the managed side then the GC will collect it and the app will fault when an event notification comes in. This could be fixed with a framework change instead, but for now this keeps the sample up and running.
