### PR TITLE
Pushing the remaining changes to MonoMac that TouchDraw uses.

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -3725,7 +3725,7 @@ namespace MonoMac.AppKit {
 		[Export ("fileType")]
 		string FileType { get; set; }
 
-		[Export ("fileURL")]
+		[Export ("fileURL"), NullAllowed]
 		NSUrl FileUrl { get; set; }
 
 		[Export ("fileModificationDate")]
@@ -3812,7 +3812,7 @@ namespace MonoMac.AppKit {
 		void WillNotPresentError (NSError error);
 
 		[Lion, Export ("setDisplayName:")]
-		void SetDisplayName ([NullAllowed] string displayNameOrNull);
+		void SetDisplayName ([NullAllowed] NSString displayNameOrNull);
 
 		[Lion, Export ("restoreDocumentWindowWithIdentifier:state:completionHandler:")]
 		void RestoreDocumentWindow (string identifier, NSCoder state, NSWindowCompletionHandler completionHandler);


### PR DESCRIPTION
Most of the additions (missing mappings) I had made to MonoMac to get 
TouchDraw for Mac done are now in the current version of MonoMac.  These 
are the only two additions/changes not in the master:

NSDocument.FileUrl can be set to null (and TouchDraw needs to do this),
so added a NullAllowed for it.

Changed the signature of NSDocument.SetDisplayName(string) to
SetDisplayName(NSString).  I did this because if that method was
overridden (which TouchDraw does) and a null value was passed into that
method from the Objective-C side, MonoMac will crash.  (Appears to be an issue
marshaling a null NSString to a c# string.)
