### PR TITLE
Adding references to NSRemoteOpenPanel and NSRemoteSavePanel for sandboxed applications

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -6084,6 +6084,9 @@ namespace MonoMac.AppKit {
 		int RunModal (string [] types);
 	}
 
+	[BaseType(typeof(NSOpenPanel))]
+	public interface NSRemoteOpenPanel {}
+
 	[BaseType (typeof (NSObject))]
 	[Model]
 	public interface NSOpenSavePanelDelegate {
@@ -9060,6 +9063,9 @@ namespace MonoMac.AppKit {
 		[Export ("runModalForDirectory:file:")]
 		int RunModal ([NullAllowed] string directory, [NullAllowed]  string filename);
 	}
+
+	[BaseType(typeof(NSSavePanel))]
+	public interface NSRemoteSavePanel {}
 
 	[BaseType (typeof (NSObject))]
 	public interface NSScreen {


### PR DESCRIPTION
Sandboxed applications do not use the common `NSOpenPanel` and `NSSavePanel` classes, calls to `[NSSavePanel savePanel]` in a sandboxed application returns a `NSRemoteSavePanel`. 

While in Objective-C this is completely fine, since this hidden class implements most of the methods from `NSSavePanel` (supposedly your Objective-C would not change at all), the fact that `NSRemoteSavePanel` inherits from `NSObject` completely breaks the binding in C#, since `NSSavePanel.OpenPanel` in C# returns a strongly typed reference to `NSSavePanel`.

To work around this issue we simply declared `NSRemoteSavePanel` (and `NSRemoteOpenPanel`) in our bindings inheriting from `NSSavePanel` and it works like a charm (or almost, since some methods might not work as expected or be available). I believe other people building MonoMac applications and targeting the app store (or sandboxed applications in general) would surely benefit from this fix.

And while not obligatory, people running in the sandbox and using these file panels [would also need this pull request](https://github.com/mono/maccore/pull/39) accepted, since you need the bookmarked data to be able to work with files in the sandbox.
