### PR TITLE
Enable thread protection

### DIFF
--- a/src/AppKit/AppKitThreadAccessException.cs
+++ b/src/AppKit/AppKitThreadAccessException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MonoMac.AppKit
+{
+	public class AppKitThreadAccessException : Exception
+	{
+		public AppKitThreadAccessException() : base("AppKit Consistency error: you are calling a method that can only be invoked from the UI thread.")
+		{
+		}
+	}
+}
+

--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -32,6 +32,9 @@ using MonoMac.ObjCRuntime;
 
 namespace MonoMac.AppKit {
 	public partial class NSApplication : NSResponder {
+		public static bool CheckForIllegalCrossThreadCalls = true;
+		private static Thread mainThread;
+
 		static NSApplication () {
 			System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof (NSObject).TypeHandle);
 			class_ptr = Class.GetHandle ("NSApplication");
@@ -58,6 +61,17 @@ namespace MonoMac.AppKit {
 				}
 			}
 
+			// Runtime hosts embedding MonoMac may use a different sync context 
+			// and call NSApplicationMain externally prior to this Init, so only
+			// initialize the context if it hasn't been set externally. Alternatively,
+			// AppKitSynchronizationContext could be made public.
+			if(SynchronizationContext.Current == null)
+				SynchronizationContext.SetSynchronizationContext (new AppKitSynchronizationContext ());
+
+			// Establish the main thread at the time of Init to support hosts
+			// that don't call Main.
+			NSApplication.mainThread = Thread.CurrentThread;
+
 			// TODO:
 			//   Install hook to register dynamically loaded assemblies
 		}
@@ -73,9 +87,21 @@ namespace MonoMac.AppKit {
 
 		public static void Main (string [] args)
 		{
-			SynchronizationContext.SetSynchronizationContext (new AppKitSynchronizationContext ());
-			
+			// Switch to an AppKitSynchronizationContext if Main is invoked
+			if(SynchronizationContext.Current == null || !typeof(AppKitSynchronizationContext).IsAssignableFrom(SynchronizationContext.Current.GetType()))
+				SynchronizationContext.SetSynchronizationContext (new AppKitSynchronizationContext ());
+
+			// Init where this is set the first time is generally paired
+			// with a call to Main, but this guarantees the right thread.
+			NSApplication.mainThread = Thread.CurrentThread;
+
 			NSApplicationMain (args.Length, args);
+		}
+
+		public static void EnsureUIThread()
+		{
+			if (NSApplication.CheckForIllegalCrossThreadCalls && NSApplication.mainThread != Thread.CurrentThread)
+				throw new AppKitThreadAccessException();
 		}
 
 		// NSEventMask is a superset (64 bits) of the mask that can be used (32 bits)

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,6 +48,7 @@ CORE_SOURCES =	$(EXTRA_CORE_SOURCES)			\
 MONOMAC_SOURCES = $(EXTRA_MONOMAC_SOURCES) \
 	./Foundation/NSObjectMac.cs			\
 	./AppKit/AppKitSynchronizationContext.cs	\
+	./AppKit/AppKitThreadAccessException.cs	\
 	./AppKit/ActionDispatcher.cs			\
 	./AppKit/BeginSheet.cs				\
 	./AppKit/DoubleWrapper.cs			\


### PR DESCRIPTION
This patch enables thread protection for MonoMac similarly to MonoTouch. The monomac patch is associated with an accompanying patch to maccore.
