### PR TITLE
Add ThreadSafe attribute to MonoMac

### DIFF
--- a/src/Make.shared
+++ b/src/Make.shared
@@ -226,6 +226,7 @@ SHARED_CORE_SOURCE = \
         ./ObjCRuntime/INativeObject.cs                  \
 	./ObjCRuntime/LionAttribute.cs			\
         ./ObjCRuntime/SinceAttribute.cs                 \
+        ./ObjCRuntime/ThreadSafeAttribute.cs                 \
         ./ObjCRuntime/TypeConverter.cs                  \
 	./MonoNativeFunctionWrapperAttribute.cs			\
 	./MonoPInvokeCallbackAttribute.cs


### PR DESCRIPTION
This attribute is required now that MonoMac supports thread checks.
