### PR TITLE
Add overlooked Foundation files from maccore to the build.

### DIFF
--- a/src/Make.shared
+++ b/src/Make.shared
@@ -96,6 +96,7 @@ SHARED_SOURCE = \
 	./Foundation/ModelNotImplementedException.cs	\
 	./Foundation/NSAutoreleasePool.cs		\
 	./Foundation/NSArray.cs				\
+	./Foundation/NSAttributedString.cs				\
 	./Foundation/NSBundle.cs			\
 	./Foundation/NSCalendar.cs			\
 	./Foundation/NSCoder.cs				\
@@ -111,9 +112,11 @@ SHARED_SOURCE = \
 	./Foundation/NSInputStream.cs			\
 	./Foundation/NSKeyedArchiver.cs			\
 	./Foundation/NSKeyedUnarchiver.cs		\
+	./Foundation/NSLocale.cs		\
 	./Foundation/NSMutableAttributedString.cs	\
 	./Foundation/NSMutableData.cs			\
 	./Foundation/NSMutableDictionary.cs		\
+	./Foundation/NSMutableSet.cs		\
 	./Foundation/NSMutableUrlRequest.cs		\
 	./Foundation/NSNotificationCenter.cs		\
 	./Foundation/NSNumber.cs			\
@@ -127,11 +130,13 @@ SHARED_SOURCE = \
 	./Foundation/NSString2.cs			\
 	./Foundation/NSThread.cs			\
 	./Foundation/NSTimer.cs				\
+	./Foundation/NSUbiquitousKeyValueStore.cs				\
 	./Foundation/NSUrl.cs				\
 	./Foundation/NSUrlConnection.cs			\
 	./Foundation/NSUrlProtocol.cs		\
 	./Foundation/NSUrlProtocolClient.cs	\
 	./Foundation/NSUserDefaults.cs			\
+	./Foundation/NSUuid.cs			\
 	./Foundation/NSValue.cs				\
 	./Foundation/ToString.cs			\
 	./ImageIO/CGImageSource.cs			\


### PR DESCRIPTION
It appears that the following files from maccore were not included in the build. NSUbiquitousKeyValueStore in particular is needed in order to gain access to setters for iCloud key/value storage.

NSAttributedString
NSLocale
NSMutableSet
NSUbiquitousKeyValueStore
NSUuid

The NSDistributedNotificationCenter.cs file was also not included, but it does not appear to contain any needed methods and so was not added back.
