### PR TITLE
Annotate a few AppKit members with ThreadSafe

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -277,7 +277,7 @@ namespace MonoMac.AppKit {
 	[BaseType (typeof (NSResponder), Delegates=new string [] { "WeakDelegate" }, Events=new Type [] { typeof (NSApplicationDelegate) })]
 	[DisableDefaultCtor] // An uncaught exception was raised: Creating more than one Application
 	public interface NSApplication : NSWindowRestoration {
-		[Export ("sharedApplication"), Static]
+		[Export ("sharedApplication"), Static, ThreadSafe]
 		NSApplication SharedApplication { get; }
 	
 		[Export ("delegate", ArgumentSemantic.Assign), NullAllowed]
@@ -346,7 +346,7 @@ namespace MonoMac.AppKit {
 		[Export ("stopModalWithCode:")]
 		void StopModalWithCode (int returnCode);
 	
-		[Export ("abortModal")]
+		[Export ("abortModal"), ThreadSafe]
 		void AbortModal ();
 	
 		[Export ("modalWindow")]
@@ -505,10 +505,10 @@ namespace MonoMac.AppKit {
 		[Export ("orderFrontColorPanel:")]
 		void OrderFrontColorPanel (NSObject sender);
 
-		[Lion, Export ("disableRelaunchOnLogin")]
+		[Lion, Export ("disableRelaunchOnLogin"), ThreadSafe]
 		void DisableRelaunchOnLogin ();
 
-		[Lion, Export ("enableRelaunchOnLogin")]
+		[Lion, Export ("enableRelaunchOnLogin"), ThreadSafe]
 		void EnableRelaunchOnLogin ();
 
 		[Lion, Export ("enabledRemoteNotificationTypes")]
@@ -14637,7 +14637,7 @@ namespace MonoMac.AppKit {
 	[BaseType (typeof (NSObject))]
 	public interface NSWorkspace {
 		[Static]
-		[Export ("sharedWorkspace")]
+		[Export ("sharedWorkspace"), ThreadSafe]
 		NSWorkspace SharedWorkspace { get; }
 		
 		[Export ("notificationCenter")]
@@ -14781,7 +14781,7 @@ namespace MonoMac.AppKit {
 		[Export ("desktopImageOptionsForScreen:")]
 		NSDictionary DesktopImageOptions (NSScreen screen);		
 		
-		[Export ("runningApplications")]
+		[Export ("runningApplications"), ThreadSafe]
 		NSRunningApplication [] RunningApplications { get; }
 
 		[Lion]


### PR DESCRIPTION
See comments on this commit:
https://github.com/mono/monomac/commit/2a986b2286adae0695cb26722483ca9b57e0172e

And bug 10604:
https://bugzilla.xamarin.com/show_bug.cgi?id=10604
