### PR TITLE
Add new Mountain Lion properties to NSColor

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -2563,6 +2563,11 @@ namespace MonoMac.AppKit {
 		[Export ("alternateSelectedControlTextColor")]
 		NSColor AlternateSelectedControlText { get; }
 
+		[MountainLion]
+		[Static]
+		[Export ("underPageBackgroundColor")]
+		NSColor UnderPageBackground { get; }
+
 		[Static]
 		[Export ("controlAlternatingRowBackgroundColors")]
 		NSColor [] ControlAlternatingRowBackgroundColors ();
@@ -2690,6 +2695,10 @@ namespace MonoMac.AppKit {
 
 		[Export ("patternImage")]
 		NSImage PatternImage { get; }
+
+		[MountainLion]
+		[Export ("CGColor")]
+		CGColor CGColor { get; }
 
 		[Export ("drawSwatchInRect:")]
 		void DrawSwatchInRect (RectangleF rect);


### PR DESCRIPTION
Add two new Mountain Lion properties to NSColor ([CGColor](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSColor_Class/Reference/Reference.html#//apple_ref/doc/uid/20000353-SW21) and [underPageBackgroundColor](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSColor_Class/Reference/Reference.html#//apple_ref/doc/uid/20000353-SW19))
