### PR TITLE
Add DomHtmlTextAreaElement bindings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -160,7 +160,7 @@ ifeq ($(HAVE_ASYNC),1)
 else
 	ASYNC_TARGETS = 
 	UPDATE_FILES = MonoMac.dll*
-	MCS ?= dmcs
+	MCS ?= gmcs
 endif
 
 TARGETS = _bmac.exe $(TARGET) parse.exe bmac.exe $(ASYNC_TARGETS)


### PR DESCRIPTION
I filed https://bugzilla.xamarin.com/show_bug.cgi?id=7754 and https://bugzilla.xamarin.com/show_bug.cgi?id=11693 because I was unable to access some properties on input and textarea elements from the DOM. The input element properties were fixed, but textarea elements were left out. I added the appropriate bindings as I needed those properties ASAP.
