### PR TITLE
Fix `MonoMac.WebKit.DomNode' does not contain definition `Value'

### DIFF
--- a/samples/SkinnableApp/MainWindowController.cs
+++ b/samples/SkinnableApp/MainWindowController.cs
@@ -180,7 +180,7 @@ namespace SkinnableApp
 		{
 			var document = webView.MainFrame.DomDocument;
 			var contentTitle = document.GetElementById("contentTitle");
-			titleText.StringValue = contentTitle.FirstChild.Value;
+			titleText.StringValue = contentTitle.FirstChild.NodeValue;
 		}
 
 		// Install the click handler for the Show Message HTML button


### PR DESCRIPTION
monomac/samples/SkinnableApp/MainWindowController.cs(52,52): Error CS1061: Type `MonoMac.WebKit.DomNode' does not contain a definition for`Value' and no extension method `Value' of type`MonoMac.WebKit.DomNode' could be found. Are you missing an assembly reference? (CS1061) (SkinnableApp)
