### PR TITLE
[docs] Bring docs Makefile up to date with maccore and general cleanup

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,12 +1,46 @@
+# Path to doc fixer and dependencies
 MACCORE=../../maccore/tools/docfixer
+
+# Path to target framework binaries (e.g. MonoMac, MonoTouch)
+BINROOT=../src
+
+# Path to temp interface assembly used for binding
+BINDING_LIB=$(BINROOT)/temp.dll
+
+# Path to MonoMac / MonoTouch
+FXLIB=$(BINROOT)/MonoMac.dll
+
+DEFINES=-define:MONOMAC
 
 .PHONY: assemble docs update-docs clean-docs install-docs
 
-DOCS_LIB = monomac-lib.tree monomac-lib.zip
-DOCS_ASSEMBLIES = ../src/monomac.dll
+BIND_TOOL = _bmac.exe
+DOCS_IDENTIFIER = monomac-docs
+DOCS_TREE = monomac-lib.tree
+DOCS_ZIP = monomac-lib.zip
+DOCS_SOURCE = monomac-docs.source
+DOCS_LIB = $(DOCS_TREE) $(DOCS_ZIP)
+DOCS_PKG = ./MonoMacDocs.pkg
+DOCS_ASSEMBLIES = $(FXLIB)
+DOCS_INSTALL = /Library/Frameworks/Mono.framework/External/monodoc
+DOCS_INSTALL2 = `pkg-config --variable=sourcesdir monodoc`
+APPLE_OSX_DOCS = `echo ~/Library/Developer/Shared/Documentation/DocSets/com.apple.adc.documentation.AppleOSX10_8.CoreReference.docset`
+APPLE_IOS_DOCS = `echo ~/Library/Developer/Shared/Documentation/DocSets/com.apple.adc.documentation.AppleiOS6.1.iOSLibrary.docset`
+NS_PREFIX=MonoMac
 
 docs: $(DOCS_MAN) $(DOCS_LIB)
 
+# Steps to build
+#  1. [update-docs] Update existing XML docs by applying assembly changes -> "en"
+#  2. [stub-docs] Update stubs that can be generated -> "en"
+#  3. [merge-apple-docs] Merge in Apple documentation -> "deploy/en"
+#  4. [docs] Build monodoc bundle from "deploy/en"
+#  5. Optionally [install-monodoc-docs] or [pkg] to an installer
+build-docs: update-docs stub-docs merge-apple-docs docs
+
+stub-docs: populate dgc
+
+merge-apple-docs: run run2
 
 update-docs:
 	mdoc update --delete $(MDOC_UPDATE_OPTIONS) -o en $(DOCS_ASSEMBLIES)
@@ -25,10 +59,11 @@ install-docs: $(DOCS_MAN)
 	(cd docs ; find en -name '*.xml' > .files)
 	(cd docs ; tar cTf .files - ) | (cd $(docdir) ; tar xf - )
 	rm .files
-	cp $(DOCS_MAN) monomac-docs.source $(docdir)
+	cp $(DOCS_MAN) $(DOCS_SOURCE) $(docdir)
 
+# Must be run as sudo
 install-monodoc-docs: $(DOCS_MAN) $(DOCS_LIB) monomac-docs.source
-install -m 644 $^ `pkg-config --variable=sourcesdir monodoc`
+	install -m 644 $^ $(DOCS_INSTALL)
 
 clean-docs:
 	-rm $(DOCS_MAN) $(DOCS_LIB)
@@ -36,9 +71,9 @@ clean-docs:
 push-docs: docs
 	scp $(DOCS_MAN) $(DOCS_LIB) monomac-docs.source root@www.go-mono.com:/usr/lib/monodoc/sources
 
-monomac-lib.tree: monomac-lib.zip
-monomac-lib.zip : Makefile
-	mdoc assemble -o $(basename $@) en
+$(DOCS_TREE): $(DOCS_ZIP)
+$(DOCS_ZIP): Makefile deploy/en
+	mdoc assemble -o $(basename $@) deploy/en
 
 fetch-shared-docs:
 	make fetch-docs TARGET=.
@@ -52,40 +87,53 @@ fetch-docs-to-compare:
 fetch-docs:
 	for i in en/*/*.xml; do d=`echo $$i | sed -e 's,MonoMac,MonoTouch,' -e s,^,../../monotouch/docs/,`; if test $$i != en/MonoMac.Security/SecKeyChain.xml -a $$i != en/MonoMac/Constants.xml; then if test -f $$d; then echo $$d; sed -e 's/MonoTouch/MonoMac/g' -e 's/<AssemblyName>monotouch/<AssemblyName>monomac/' < $$d > $(TARGET)/$$i; fi; fi; done
 
-
 populate: populate.exe
-	MONO_PATH=../src mono --debug populate.exe .
+	MONO_PATH=$(BINROOT) mono --debug populate.exe .
 
 populate.exe: populate.cs
-	dmcs populate.cs -r:../src/MonoMac.dll -r:System.Xml.Linq
+	dmcs populate.cs -r:$(FXLIB) -r:System.Xml.Linq
 
-docfixer.exe: $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs AgilityPack.dll
-	gmcs -out:$@ -debug+ $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs -r:AgilityPack.dll -r:../src/MonoMac.dll -r:System.Xml.Linq -r:System.Xml
+docfixer.exe: $(MACCORE)/docfixer.cs $(MACCORE)/AppleDocMerger.cs $(MACCORE)/AppleDocKnownIssues.cs $(MACCORE)/Options.cs $(MACCORE)/MDocArchive.cs $(MACCORE)/samples.cs $(MACCORE)/SQLite.cs AgilityPack.dll Mono.Cecil.dll Ionic.Zip.dll $(FXLIB)
+	dmcs -out:$@ -debug+ $(MACCORE)/docfixer.cs $(MACCORE)/AppleDocMerger.cs $(MACCORE)/AppleDocKnownIssues.cs $(MACCORE)/Options.cs $(MACCORE)/MDocArchive.cs $(MACCORE)/samples.cs $(MACCORE)/SQLite.cs -r:AgilityPack.dll -r:$(FXLIB) -r:System.Xml.Linq -r:System.Xml -r:$(MACCORE)/Mono.Cecil.dll -r:$(MACCORE)/Ionic.Zip.dll
 
 dgc: document-generated-code
 
 document-generated-code: document-generated-code.exe
-	MONO_PATH=../src mono --debug document-generated-code.exe ../src/temp.dll .
+	MONO_PATH=$(BINROOT) mono --debug document-generated-code.exe --ns-prefix=$(NS_PREFIX) $(BINDING_LIB) .
 
-document-generated-code.exe: $(MACCORE)/document-generated-code.cs AgilityPack.dll $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs
-	dmcs -debug -main:DocumentGeneratedCode -out:document-generated-code.exe $(MACCORE)/document-generated-code.cs $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs -r:System.Xml.Linq -r:../src/_bmac.exe -r:../src/core.dll -define:MONOMAC -r:AgilityPack.dll
+document-generated-code.exe: $(MACCORE)/document-generated-code.cs $(MACCORE)/docfixer.cs $(MACCORE)/AppleDocMerger.cs $(MACCORE)/AppleDocKnownIssues.cs $(MACCORE)/MDocArchive.cs $(MACCORE)/samples.cs $(MACCORE)/SQLite.cs AgilityPack.dll Mono.Cecil.dll Ionic.Zip.dll $(BINROOT)/$(BIND_TOOL) $(BINROOT)/core.dll
+	dmcs -debug -main:DocumentGeneratedCode -out:document-generated-code.exe $(MACCORE)/document-generated-code.cs $(MACCORE)/docfixer.cs $(MACCORE)/AppleDocMerger.cs $(MACCORE)/AppleDocKnownIssues.cs $(MACCORE)/MDocArchive.cs $(MACCORE)/samples.cs $(MACCORE)/SQLite.cs -r:System.Xml.Linq -r:$(BINROOT)/$(BIND_TOOL) -r:$(BINROOT)/core.dll -r:AgilityPack.dll -r:$(MACCORE)/Mono.Cecil.dll -r:$(MACCORE)/Ionic.Zip.dll $(DEFINES)
+
+pkg: $(DOCS_ZIP)
+	-mkdir deploy/pkgroot
+	cp $(DOCS_TREE) deploy/pkgroot
+	cp $(DOCS_ZIP) deploy/pkgroot
+	cp $(DOCS_SOURCE) deploy/pkgroot
+	pkgbuild --identifier $(DOCS_IDENTIFIER) --root deploy/pkgroot --install-location $(DOCS_INSTALL) $(PKG_SIGN) $(DOCS_PKG)
 
 run: docfixer.exe 
 	-mkdir deploy
 	rsync -a en deploy
 	chmod -R +rw deploy
-	MONO_PATH=../src mono --debug docfixer.exe --summary deploy
+	MONO_PATH=$(BINROOT) mono --debug docfixer.exe --allow-missing=300 --use-raw-doc --reference-assembly=$(FXLIB) --ns-prefix=$(NS_PREFIX) --apple-doc-dir=$(APPLE_OSX_DOCS) deploy
 
 #
 # this second stage documents other bits, using the metadata from the API definition file, not the resulting assembly
 #
 run2: document-generated-code.exe
-	MONO_PATH=../src mono --debug document-generated-code.exe --appledocs ../src/temp.dll deploy
+	MONO_PATH=$(BINROOT) mono --debug document-generated-code.exe --ns-prefix=$(NS_PREFIX) --apple-doc-dir=$(APPLE_OSX_DOCS) $(BINDING_LIB) deploy
 
 push:
 	rsync -a deploy/en/ root@mono.ximian.com:/srv/www/mono-website/monomac-docs/Docs/monomac.dll
+	
 AgilityPack.dll: $(MACCORE)/AgilityPack.dll
 	cp $< $@
+	
+Mono.Cecil.dll: $(MACCORE)/Mono.Cecil.dll
+	cp $< $@
 
+Ionic.Zip.dll: $(MACCORE)/Ionic.Zip.dll
+	cp $< $@
+	
 audit: document-generated-code.exe
-	MONO_PATH=../src mono --debug document-generated-code.exe --debugdoc  ../src/temp.dll deploy > log
+	MONO_PATH=$(BINROOT) mono --debug document-generated-code.exe --ns-prefix=$(NS_PREFIX) --debugdoc $(BINDING_LIB) deploy > log


### PR DESCRIPTION
This brings the Makefile up to date with recent changes to maccore for building the docs.

Relates to https://github.com/mono/maccore/pull/55
