### PR TITLE
Strongly type the cell of NSTextField

### DIFF
--- a/src/AppKit/NSTextField.cs
+++ b/src/AppKit/NSTextField.cs
@@ -1,0 +1,17 @@
+//
+// NSTextField.cs: Support for the NSTextField class
+//
+using System;
+using MonoMac.ObjCRuntime;
+using MonoMac.Foundation;
+
+namespace MonoMac.AppKit {
+
+	public partial class NSTextField {
+		public new NSTextFieldCell Cell {
+			get { return (NSTextFieldCell)base.Cell; }
+			set { base.Cell = value; }
+		}
+	}
+}
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ MONOMAC_SOURCES = $(EXTRA_MONOMAC_SOURCES) \
 	./AppKit/NSSpellChecker.cs			\
 	./AppKit/NSSound.cs				\
 	./AppKit/NSTableView.cs				\
+	./AppKit/NSTextField.cs				\
         ./AppKit/NSToolbarItem.cs                       \
 	./AppKit/NSTreeController.cs			\
 	./AppKit/NSView.cs				\


### PR DESCRIPTION
Similar to what was done for NSButton and NSPopUpButton with https://github.com/mono/monomac/commit/501903ce97634578fdf4bf4408e6e51dde06bdfa.

This makes it simpler to set properties such as `PlaceholderString` programmatically.

Before this change, you'd have to manually cast NSTextField's Cell property to NSTextFieldCell like this:

``` c#
((NSTextFieldCell)myTextField.Cell).PlaceholderString = "Search";
```

After this change, you can simply do this:

``` c#
myTextField.Cell.PlaceholderString = "Search";
```
