### PR TITLE
Fix crash in macdoc

### DIFF
--- a/samples/macdoc/MyDocument.cs
+++ b/samples/macdoc/MyDocument.cs
@@ -514,6 +514,9 @@ namespace macdoc
 		
 		int ScrollToVisible (Node n)
 		{
+			if (!nodeToWrapper.ContainsKey (n))
+				return 0;
+
 			var item = nodeToWrapper [n];
 			var row = outlineView.RowForItem (item);
 			outlineView.ScrollRowToVisible (row);


### PR DESCRIPTION
ScrollToVisible is sometimes called on the previous node, and in some cases this previous node does not have a registered wrapper which causes macdoc to crash. This fix adds a check for the node instead of throwing.
