### PR TITLE
Corrected a dead link.

### DIFF
--- a/samples/RoundedTransparentWindow/README
+++ b/samples/RoundedTransparentWindow/README
@@ -1,6 +1,6 @@
 A port of the RoundedDisplayWindow sample:
 
-http://developer.apple.com/library/mac/#samplecode/RoundTransparentWindow/Introduction/Intro.html
+http://developer.apple.com/library/mac/samplecode/RoundTransparentWindow/Introduction/Intro.html
 
 Slightly updated to avoid using the deprecated APIs in the sample.
 


### PR DESCRIPTION
I found a dead link in the documentation of a sample. It seems the hash was stopping the link from working.
