### PR TITLE
Fix broken build when build

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,4 +1,5 @@
-MDTOOL=/Applications/MonoDevelop.app/Contents/MacOS/mdtool
+MDROOT = $(shell stat -f%N "/Applications/Xamarin Studio.app" 2>/dev/null || echo "/Applications/MonoDevelop.app")
+MDTOOL="$(MDROOT)/Contents/MacOS/mdtool"
 
 XDIRS = \
 	NSAlert					\


### PR DESCRIPTION
Build failed because I only have Xamarin Studio installed, not Monodevelop. This fixes the build.
