### PR TITLE
Fix NSDocumentChangeType

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -827,7 +827,8 @@ namespace MonoMac.AppKit {
 #region NSDocument
 
 	public enum NSDocumentChangeType  {
-		Done, Undone, Cleared, Redone, ReadOtherContents, Autosaved
+		Done, Undone, Cleared, ReadOtherContents, Autosaved, Redone,
+		Discardable = 256 /* New in Lion */
 	}
 
 	public enum NSSaveOperationType  {


### PR DESCRIPTION
The values of ReadOtherContents, Autosaved and Redone were incorrect.

This PR fixes them as per https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSDocument_Class/Reference/Reference.html#//apple_ref/doc/c_ref/NSDocumentChangeType
