### PR TITLE
Expose test of whether NSApplication.Init() has been run

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -45,6 +45,12 @@ namespace MonoMac.AppKit {
 
 		static bool initialized;
 
+		public static bool Initialized {
+			get {
+				return initialized;
+			}
+		}
+
 		public static void Init ()
 		{
 			if (initialized) {


### PR DESCRIPTION
This test will facilitate frameworks like XWT, to keep code more generic for multiple platforms which need to call Init at different times during an application session (e.g. Mac XWT widget in a Mac app, as opposed to Mac XWT widget inside of a GTK app).
