### PR TITLE
Add few missing methods in NSGraphics

### DIFF
--- a/src/AppKit/NSGraphics.cs
+++ b/src/AppKit/NSGraphics.cs
@@ -198,5 +198,17 @@ namespace MonoMac.AppKit {
 					return DrawTiledRects (aRect, clipRect, ptr, ptr2, sides.Length);
 			}
 		}
+
+        [DllImport (Constants.AppKitLibrary, EntryPoint="NSDrawWindowBackground")]
+        public extern static void DrawWindowBackground (RectangleF aRect);
+
+        [DllImport (Constants.AppKitLibrary, EntryPoint="NSSetFocusRingStyle")]
+        public extern static void SetFocusRingStyle (NSFocusRingPlacement placement);
+
+        [DllImport (Constants.AppKitLibrary, EntryPoint="NSDisableScreenUpdates")]
+        public extern static void DisableScreenUpdates ();
+
+        [DllImport (Constants.AppKitLibrary, EntryPoint="NSEnableScreenUpdates")]
+        public extern static void EnableScreenUpdates ();
 	}
 }


### PR DESCRIPTION
I'm working on porting a 'popular' Cocoa library to pure MonoMac implementation that require some of these methods. I'm using a custom built dll for now but hoping these changes get merged soon so that I don't have to.
