### PR TITLE
Fix NSDocumentController.SharedDocumentController return type

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -4011,7 +4011,7 @@ namespace MonoMac.AppKit {
 	[BaseType (typeof (NSObject))]
 	public partial interface NSDocumentController : NSWindowRestoration {
 		[Static, Export ("sharedDocumentController")]
-		NSObject SharedDocumentController { get; }
+		NSDocumentController SharedDocumentController { get; }
 
 		[Export ("documents")]
 		NSDocument [] Documents { get; }


### PR DESCRIPTION
See http://forums.xamarin.com/discussion/17120/why-is-nsdocumentcontroller-shareddocumentcontroller-exposed-as-an-nsobject
