### PR TITLE
Fix `make` for Mono 4.x installs as `gmcs` is being called

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -60,7 +60,7 @@ populate.exe: populate.cs
 	dmcs populate.cs -r:../src/MonoMac.dll -r:System.Xml.Linq
 
 docfixer.exe: $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs AgilityPack.dll
-	gmcs -out:$@ -debug+ $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs -r:AgilityPack.dll -r:../src/MonoMac.dll -r:System.Xml.Linq -r:System.Xml
+	mcs -out:$@ -debug+ $(MACCORE)/docfixer.cs $(MACCORE)/docfixer.mm.cs -r:AgilityPack.dll -r:../src/MonoMac.dll -r:System.Xml.Linq -r:System.Xml
 
 dgc: document-generated-code
 

--- a/samples/MicroSamples/Makefile
+++ b/samples/MicroSamples/Makefile
@@ -16,10 +16,10 @@ MonoMac.dll: $(MONOMAC_DLL)
 	cp "$<" $@
 
 generate-pdf.exe: MonoMac.dll generate-pdf.cs
-	gmcs generate-pdf.cs -r:MonoMac.dll -r:System.Drawing
+	mcs generate-pdf.cs -r:MonoMac.dll -r:System.Drawing
 
 locator.exe: MonoMac.dll locator.cs
-	gmcs locator.cs -r:MonoMac.dll
+	mcs locator.cs -r:MonoMac.dll
 
 HelloCoreWlanSample.exe: MonoMac.dll HelloCoreWlanSample.cs
-	gmcs HelloCoreWlanSample.cs -r:MonoMac.dll
+	mcs HelloCoreWlanSample.cs -r:MonoMac.dll

--- a/samples/attic/Hello/Makefile
+++ b/samples/attic/Hello/Makefile
@@ -1,6 +1,6 @@
 all:
 	cp ../../../src/MonoMac.dll* Hello.app/Contents/Resources/
-	gmcs -debug -main:Demo hello.cs -out:Hello.app/Contents/Resources/Hello.exe -r:System.Drawing -r:Hello.app/Contents/Resources/MonoMac.dll 
+	mcs -debug -main:Demo hello.cs -out:Hello.app/Contents/Resources/Hello.exe -r:System.Drawing -r:Hello.app/Contents/Resources/MonoMac.dll 
 
 run:
 	./Hello.app/Contents/MacOS/Hello 


### PR DESCRIPTION
`make all` is failing under Mono 4.x as `gmcs` is being used in 3 build instances