### PR TITLE
Fix missing reference to maccore CoreAnimation/CAEmitterCell.cs

### DIFF
--- a/src/Make.shared
+++ b/src/Make.shared
@@ -41,6 +41,7 @@ SHARED_SOURCE = \
 	./AVFoundation/AVLayerVideoGravity.cs		\
 	./AVFoundation/AVAssetReaderVideoCompositionOutput.cs	\
 	./CoreAnimation/CADefs.cs			\
+	./CoreAnimation/CAEmitterCell.cs		\
 	./CoreAnimation/CALayer.cs			\
 	./CoreAnimation/CATextLayer.cs			\
 	./CoreAnimation/CAMediaTimingFunction.cs	\


### PR DESCRIPTION
MonoMac project is missing the maccore CoreAnimation/CAEmitterCell.cs in the Make.shared file.

This prevents the ability to assign an Image to the emitter via the `Content` property