### PR TITLE
[macdoc] Build macdoc for 10.7 minimum

### DIFF
--- a/samples/macdoc/Info.plist
+++ b/samples/macdoc/Info.plist
@@ -62,7 +62,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>10.7</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2012 Xamarin, Inc.</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
10.6 doesn't appear to be supported anymore